### PR TITLE
Update MiniPlayer.java

### DIFF
--- a/java/sage/MiniPlayer.java
+++ b/java/sage/MiniPlayer.java
@@ -867,7 +867,7 @@ public class MiniPlayer implements DVDMediaPlayer
             }
             Thread.currentThread().setPriority(oldPriority);
             if (!mcsr.isLocalConnection() && uiBandwidthEstimate < 10000000 &&
-                uiBandwidthEstimate >= Sage.getInt("miniplayer/min_bandwidth_for_no_transcode", 2000000))
+                uiBandwidthEstimate >= Sage.getInt("miniplayer/min_bandwidth_for_no_transcode", 2000000) && Sage.getBoolean("miniplayer/wan_prevent_push", true))
             {
               if (Sage.DBG) System.out.println("Detected non-LAN connection under 10Mbps but above set limit (" + uiBandwidthEstimate +
                   "), force it to transcode mode");


### PR DESCRIPTION
Logic update to allow user to opt out of forced transcode on non-lan streaming. Existing logic forced transcode to prevent nat /port forwarding issues.

Adding line miniplayer/wan_prevent_push (defaults to true if not set) with a value of false should allow streaming. Use case is a vpn link.